### PR TITLE
Polish web stream controls

### DIFF
--- a/apps/web/src/components/app/not-found.tsx
+++ b/apps/web/src/components/app/not-found.tsx
@@ -1,3 +1,5 @@
+import { ButtonLink } from "@/components/ui/button";
+
 export function NotFound() {
   return (
     <main className="dark flex min-h-svh items-center justify-center bg-background px-6 text-foreground">
@@ -9,12 +11,9 @@ export function NotFound() {
         <p className="text-muted-foreground text-sm">
           The page you're looking for doesn't exist or has been moved.
         </p>
-        <a
-          className="mt-2 inline-flex h-action items-center justify-center rounded-md border border-border bg-card px-4 text-sm transition-colors hover:bg-accent"
-          href="/"
-        >
+        <ButtonLink className="mt-2" href="/" variant="outline">
           Back to home
-        </a>
+        </ButtonLink>
       </div>
     </main>
   );

--- a/apps/web/src/components/session/camera-select.tsx
+++ b/apps/web/src/components/session/camera-select.tsx
@@ -12,6 +12,7 @@ import { ToolbarSeparator } from "@/components/ui/toolbar";
 
 type Props = {
   cameraId: string | null;
+  reserve?: boolean;
   setCameraId: (cameraId: string | null) => void;
 };
 
@@ -21,12 +22,19 @@ const cleanLabel = (label: string) =>
 const labelFor = (device: Pick<MediaDeviceInfo, "label">, index: number) =>
   cleanLabel(device.label) || `Camera ${index + 1}`;
 
+const triggerLabelFor = (label: string) =>
+  label.replace(/\s+(?:virtual\s+camera|web\s+camera|webcam|camera)$/i, "") ||
+  label;
+
 const mediaDevicesOptions = {
   constraints: { audio: false, video: true },
 };
 
+const triggerWidth = "clamp(7rem, 24vw, 10rem)";
+
 export const CameraSelect = memo(function CameraSelect({
   cameraId,
+  reserve = false,
   setCameraId,
 }: Props) {
   const [{ devices }] = useMediaDevices(mediaDevicesOptions);
@@ -34,8 +42,26 @@ export const CameraSelect = memo(function CameraSelect({
     () => devices.filter((device) => device.kind === "videoinput"),
     [devices],
   );
+  const selectedIndex = cameras.findIndex((d) => d.deviceId === cameraId);
+  const selectedLabel =
+    selectedIndex === -1
+      ? "Select camera"
+      : labelFor(cameras[selectedIndex], selectedIndex);
 
-  if (cameras.length < 2) return null;
+  if (cameras.length < 2) {
+    if (!reserve) return null;
+
+    return (
+      <>
+        <ToolbarSeparator orientation="vertical" />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none shrink-0"
+          style={{ width: triggerWidth }}
+        />
+      </>
+    );
+  }
 
   return (
     <>
@@ -45,8 +71,9 @@ export const CameraSelect = memo(function CameraSelect({
           <TooltipTrigger
             render={
               <SelectTrigger
-                className="w-control-select border-input bg-overlay"
+                className="min-w-0 border-input bg-overlay"
                 size="sm"
+                style={{ width: triggerWidth }}
               />
             }
           >
@@ -55,11 +82,11 @@ export const CameraSelect = memo(function CameraSelect({
                 if (typeof value !== "string") return null;
                 const index = cameras.findIndex((d) => d.deviceId === value);
                 if (index === -1) return null;
-                return labelFor(cameras[index], index);
+                return triggerLabelFor(labelFor(cameras[index], index));
               }}
             </SelectValue>
           </TooltipTrigger>
-          <TooltipPopup>Select camera</TooltipPopup>
+          <TooltipPopup>{selectedLabel}</TooltipPopup>
         </Tooltip>
         <SelectContent>
           {cameras.map((device, index) => (

--- a/apps/web/src/components/session/dev-panel.tsx
+++ b/apps/web/src/components/session/dev-panel.tsx
@@ -1,6 +1,8 @@
 import { DownloadIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { cfg } from "@hand-wave/contract";
+import { Button } from "@/components/ui/button";
+import { Surface } from "@/components/ui/surface";
 import { useDevStore } from "@/stores/dev-store";
 import type { DevRecording, DevTrace } from "@/types/dev";
 
@@ -70,17 +72,14 @@ function DevPanelContent() {
 
   return (
     <div className="pointer-events-none w-dev-panel max-w-full">
-      <div className="pointer-events-auto rounded-xl border bg-toolbar p-3 font-mono text-card-foreground text-xs leading-relaxed shadow-sm backdrop-blur-md">
+      <Surface
+        className="pointer-events-auto font-mono text-xs leading-relaxed"
+        padding="sm"
+      >
         <div className="mb-2 flex items-center justify-between gap-3">
           <span className="text-muted-foreground">Dev</span>
           <div className="flex items-center gap-1">
-            <button
-              className={[
-                "inline-flex items-center rounded border border-input px-1.5 py-0.5 transition-colors hover:bg-accent",
-                recording
-                  ? "bg-destructive text-destructive-foreground"
-                  : "text-foreground",
-              ].join(" ")}
+            <Button
               onClick={() => {
                 if (recording) {
                   stopRecording();
@@ -89,25 +88,26 @@ function DevPanelContent() {
                 }
                 startRecording(prompt("Trace label")?.trim() || "unlabeled");
               }}
-              type="button"
+              size="xs"
+              variant={recording ? "destructive" : "outline"}
             >
               {recording ? "Stop" : "Rec"}
-            </button>
-            <button
-              className="inline-flex items-center gap-1 rounded border border-input px-1.5 py-0.5 text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+            </Button>
+            <Button
               disabled={!canExport}
               onClick={() => downloadTraces(traces, exportRecordings)}
-              type="button"
+              size="xs"
+              variant="outline"
             >
               <DownloadIcon className="size-3" />
               Trace
-            </button>
+            </Button>
           </div>
         </div>
         <div className="mb-2 space-y-1.5 border-b pb-2">
           <textarea
             aria-label="Trace batch labels"
-            className="h-16 w-full resize-none rounded border border-input bg-background/70 px-2 py-1 text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="h-16 w-full resize-none rounded-md border border-input bg-background/70 px-2 py-1 text-foreground outline-none transition-[background-color,border-color,box-shadow] duration-150 ease-out focus-visible:ring-1 focus-visible:ring-ring motion-reduce:transition-none"
             onChange={(event) => setBatchText(event.currentTarget.value)}
             placeholder="one label per line"
             spellCheck={false}
@@ -120,30 +120,30 @@ function DevPanelContent() {
                 : `${batchLabels.length} queued`}
             </span>
             <div className="flex shrink-0 items-center gap-1">
-              <button
-                className="inline-flex items-center rounded border border-input px-1.5 py-0.5 text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+              <Button
                 disabled={!canStartBatch}
                 onClick={startBatch}
-                type="button"
+                size="xs"
+                variant="outline"
               >
                 Start
-              </button>
-              <button
-                className="inline-flex items-center rounded border border-input px-1.5 py-0.5 text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+              </Button>
+              <Button
                 disabled={batchIndex === null || !recording}
                 onClick={nextBatchLabel}
-                type="button"
+                size="xs"
+                variant="outline"
               >
                 Next
-              </button>
-              <button
-                className="inline-flex items-center rounded border border-input px-1.5 py-0.5 text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+              </Button>
+              <Button
                 disabled={batchIndex === null && !recording}
                 onClick={finishBatch}
-                type="button"
+                size="xs"
+                variant="outline"
               >
                 Finish
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -172,7 +172,7 @@ function DevPanelContent() {
             </div>
           );
         })}
-      </div>
+      </Surface>
     </div>
   );
 }

--- a/apps/web/src/components/session/idle-stage.tsx
+++ b/apps/web/src/components/session/idle-stage.tsx
@@ -6,11 +6,13 @@ type Props = {
 
 export function IdleStage({ error }: Props) {
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="space-y-3 text-center">
+    <div className="flex h-full w-full items-center justify-center px-6 pb-20 pt-8">
+      <div className="max-w-xs space-y-3 text-center">
         <MonitorOff className="mx-auto size-14 text-muted-foreground" />
-        <p className="font-medium">{error ?? "No active stream"}</p>
-        <p className="text-muted-foreground text-sm">
+        <p className="text-balance font-medium">
+          {error ?? "No active stream"}
+        </p>
+        <p className="text-muted-foreground text-pretty text-sm">
           Use the controls below to start camera or screen share
         </p>
       </div>

--- a/apps/web/src/components/session/prediction-overlay.tsx
+++ b/apps/web/src/components/session/prediction-overlay.tsx
@@ -5,11 +5,13 @@ import {
   m,
   useReducedMotion,
 } from "motion/react";
+import { surfaceVariants } from "@/components/ui/surface-variants";
+import { cn } from "@/lib/utils";
 import { useDetectionsStore } from "@/stores/detections-store";
 
 const easeOut = [0.23, 1, 0.32, 1] as const;
-const hidden = { opacity: 0 };
-const shown = { opacity: 1 };
+const hidden = { filter: "blur(4px)", opacity: 0, scale: 0.98, y: -4 };
+const shown = { filter: "blur(0px)", opacity: 1, scale: 1, y: 0 };
 const instantTransition = { duration: 0 };
 const visibleTransition = { duration: 0.16, ease: easeOut };
 
@@ -20,11 +22,14 @@ export function PredictionOverlay() {
 
   return (
     <LazyMotion features={domAnimation}>
-      <AnimatePresence>
+      <AnimatePresence initial={false}>
         {prediction ? (
           <m.div
             animate={shown}
-            className="inline-flex max-w-dev-panel min-w-0 items-center rounded-xl border bg-toolbar px-3 py-2 text-card-foreground shadow-sm backdrop-blur-md"
+            className={cn(
+              surfaceVariants(),
+              "inline-flex max-w-dev-panel min-w-0 items-center px-3 py-2",
+            )}
             exit={hidden}
             initial={shouldReduceMotion ? false : hidden}
             transition={transition}

--- a/apps/web/src/components/session/stage-view.tsx
+++ b/apps/web/src/components/session/stage-view.tsx
@@ -32,7 +32,7 @@ export function Stage() {
     <div
       ref={stageRef}
       className={cn(
-        "relative aspect-video w-full overflow-hidden border bg-stage",
+        "relative aspect-video w-full overflow-hidden border bg-stage shadow-[0_28px_90px_rgba(0,0,0,0.36),0_2px_10px_rgba(0,0,0,0.24)] outline outline-1 -outline-offset-1 outline-white/10",
         full ? "rounded-none" : "rounded-2xl",
       )}
     >

--- a/apps/web/src/components/session/stream-toolbar.tsx
+++ b/apps/web/src/components/session/stream-toolbar.tsx
@@ -9,8 +9,8 @@ import {
   Star,
   Video,
 } from "lucide-react";
-import { memo, useCallback, type ReactElement } from "react";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Fragment, memo, useCallback, type ReactElement } from "react";
+import { Button, ButtonLink } from "@/components/ui/button";
 import {
   Toolbar,
   ToolbarGroup,
@@ -58,11 +58,11 @@ export const StreamToolbar = memo(function StreamToolbar({
       <TooltipProvider delay={350}>
         <Toolbar
           aria-label="Stream controls"
-          className="h-control-center items-center gap-1 bg-toolbar px-1.5 py-1 backdrop-blur-md"
+          className="min-h-control-center w-fit max-w-[calc(100svw-1.5rem)] flex-nowrap items-center justify-center gap-1 px-1.5 py-1"
         >
-          <ToolbarGroup>
+          <ToolbarGroup className="shrink-0 justify-center">
             {isCapturing ? (
-              <ControlTooltip label="Stop sharing">
+              <ControlTooltip key="stop-sharing" label="Stop sharing">
                 <TooltipTrigger
                   render={
                     <Button
@@ -77,19 +77,26 @@ export const StreamToolbar = memo(function StreamToolbar({
                 </TooltipTrigger>
               </ControlTooltip>
             ) : (
-              <>
+              <Fragment key="start-actions">
                 <ControlTooltip label="Share screen">
                   <TooltipTrigger
-                    render={<Button onClick={startScreen} size="sm" />}
+                    render={
+                      <Button
+                        aria-label="Share screen"
+                        onClick={startScreen}
+                        size="sm"
+                      />
+                    }
                   >
                     <Share2 />
-                    Share Screen
+                    <span className="hidden sm:inline">Share Screen</span>
                   </TooltipTrigger>
                 </ControlTooltip>
                 <ControlTooltip label="Start camera">
                   <TooltipTrigger
                     render={
                       <Button
+                        aria-label="Start camera"
                         onClick={startCamera}
                         size="sm"
                         variant="outline"
@@ -97,15 +104,19 @@ export const StreamToolbar = memo(function StreamToolbar({
                     }
                   >
                     <Video />
-                    Start Camera
+                    <span className="hidden sm:inline">Start Camera</span>
                   </TooltipTrigger>
                 </ControlTooltip>
-              </>
+              </Fragment>
             )}
           </ToolbarGroup>
 
           {isCamera && (
-            <CameraSelect cameraId={cameraId} setCameraId={setCameraId} />
+            <CameraSelect
+              cameraId={cameraId}
+              reserve={state.status === "starting"}
+              setCameraId={setCameraId}
+            />
           )}
 
           <ToolbarSeparator orientation="vertical" />
@@ -145,15 +156,14 @@ export const StreamToolbar = memo(function StreamToolbar({
           <ControlTooltip label="Star on GitHub">
             <TooltipTrigger
               render={
-                <a
+                <ButtonLink
                   aria-label="Star hand-wave on GitHub"
-                  className={buttonVariants({
-                    size: "icon-sm",
-                    variant: "ghost",
-                  })}
+                  className="max-sm:hidden"
                   href={repositoryUrl}
                   rel="noreferrer"
+                  size="icon-sm"
                   target="_blank"
+                  variant="ghost"
                 />
               }
             >

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps, ReactElement } from "react";
 import { cn } from "@/lib/utils";
 
 export const buttonVariants = cva(
-  "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg border font-medium outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg border font-medium outline-none transition-[background-color,border-color,color,box-shadow,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 disabled:active:scale-100 motion-reduce:transition-none motion-reduce:active:scale-100 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     defaultVariants: {
       size: "sm",
@@ -11,8 +11,9 @@ export const buttonVariants = cva(
     },
     variants: {
       size: {
-        sm: "h-8 px-2.5 text-sm sm:h-7",
-        "icon-sm": "size-8 sm:size-7",
+        xs: "h-7 gap-1 rounded-md px-2 text-xs",
+        sm: "h-9 px-3 text-sm sm:h-8 sm:px-2.5",
+        "icon-sm": "size-9 sm:size-8",
       },
       variant: {
         default:
@@ -34,6 +35,11 @@ type ButtonProps = ComponentProps<"button"> & {
   size?: VariantProps<typeof buttonVariants>["size"];
 };
 
+type ButtonLinkProps = ComponentProps<"a"> & {
+  variant?: VariantProps<typeof buttonVariants>["variant"];
+  size?: VariantProps<typeof buttonVariants>["size"];
+};
+
 export function Button({
   className,
   variant,
@@ -47,5 +53,23 @@ export function Button({
       type="button"
       {...props}
     />
+  );
+}
+
+export function ButtonLink({
+  children,
+  className,
+  variant,
+  size,
+  ...props
+}: ButtonLinkProps): ReactElement {
+  return (
+    <a
+      className={cn(buttonVariants({ className, size, variant }))}
+      data-slot="button-link"
+      {...props}
+    >
+      {children}
+    </a>
   );
 }

--- a/apps/web/src/components/ui/empty.tsx
+++ b/apps/web/src/components/ui/empty.tsx
@@ -1,8 +1,10 @@
+import { cva } from "class-variance-authority";
 import type { ComponentProps, ReactElement } from "react";
 import { cn } from "@/lib/utils";
 
-const mediaClassName =
-  "relative flex size-9 shrink-0 items-center justify-center rounded-md border bg-card text-foreground shadow-sm/5 [&_svg]:size-4.5 [&_svg]:shrink-0";
+const emptyMediaFrameVariants = cva(
+  "relative flex size-9 shrink-0 items-center justify-center rounded-md border bg-card text-foreground shadow-sm/5 [&_svg]:size-4.5 [&_svg]:shrink-0",
+);
 
 export function Empty({
   className,
@@ -51,19 +53,19 @@ export function EmptyMedia({
     >
       <div
         aria-hidden="true"
-        className={cn(
-          mediaClassName,
-          "pointer-events-none absolute bottom-px origin-bottom-left -translate-x-0.5 -rotate-10 scale-84 shadow-none",
-        )}
+        className={emptyMediaFrameVariants({
+          className:
+            "pointer-events-none absolute bottom-px origin-bottom-left -translate-x-0.5 -rotate-10 scale-84 shadow-none",
+        })}
       />
       <div
         aria-hidden="true"
-        className={cn(
-          mediaClassName,
-          "pointer-events-none absolute bottom-px origin-bottom-right translate-x-0.5 rotate-10 scale-84 shadow-none",
-        )}
+        className={emptyMediaFrameVariants({
+          className:
+            "pointer-events-none absolute bottom-px origin-bottom-right translate-x-0.5 rotate-10 scale-84 shadow-none",
+        })}
       />
-      <div className={mediaClassName}>{children}</div>
+      <div className={emptyMediaFrameVariants()}>{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { cva, type VariantProps } from "class-variance-authority";
 import {
   ChevronDownIcon,
   ChevronsUpDownIcon,
@@ -11,17 +12,77 @@ import { cn } from "@/lib/utils";
 
 export const Select: typeof SelectPrimitive.Root = SelectPrimitive.Root;
 
-const triggerClassName =
-  "inline-flex min-h-8 w-full min-w-36 select-none items-center justify-between gap-1.5 rounded-lg border border-input bg-background px-2.5 text-left text-sm text-foreground shadow-xs/5 outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24 data-disabled:pointer-events-none data-disabled:opacity-64 dark:bg-input/32 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0";
+const selectTriggerVariants = cva(
+  "inline-flex w-full min-w-36 select-none items-center justify-between gap-1.5 rounded-lg border border-input bg-background text-left text-sm text-foreground shadow-xs/5 outline-none transition-[background-color,border-color,color,box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24 data-disabled:pointer-events-none data-disabled:opacity-64 motion-reduce:transition-none dark:bg-input/32 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    defaultVariants: {
+      size: "sm",
+    },
+    variants: {
+      size: {
+        sm: "min-h-8 px-2.5",
+      },
+    },
+  },
+);
+
+const selectPopupVariants = cva(
+  "origin-(--transform-origin) text-foreground outline-none transition-[opacity,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] data-[ending-style]:scale-95 data-[starting-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 motion-reduce:transition-none",
+);
+
+const selectScrollArrowVariants = cva(
+  "z-50 flex h-6 w-full cursor-default items-center justify-center before:pointer-events-none before:absolute before:inset-x-px before:h-[200%] before:from-50% before:from-popover",
+  {
+    variants: {
+      direction: {
+        down: "bottom-0 before:bottom-px before:rounded-b-[calc(var(--radius-lg)-1px)] before:bg-linear-to-t",
+        up: "top-0 before:top-px before:rounded-t-[calc(var(--radius-lg)-1px)] before:bg-linear-to-b",
+      },
+    },
+  },
+);
+
+const selectSurfaceVariants = cva(
+  "relative h-full min-w-(--anchor-width) rounded-lg border bg-popover not-dark:bg-clip-padding shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+);
+
+const selectListVariants = cva("max-h-(--available-height) overflow-y-auto", {
+  defaultVariants: {
+    density: "compact",
+  },
+  variants: {
+    density: {
+      compact: "p-0.5",
+    },
+  },
+});
+
+const selectItemVariants = cva(
+  "grid in-data-[side=none]:min-w-[calc(var(--anchor-width)+0.75rem)] cursor-default grid-cols-[minmax(0,1fr)_1rem] items-center gap-2 rounded-sm outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    defaultVariants: {
+      size: "sm",
+    },
+    variants: {
+      size: {
+        sm: "min-h-8 py-1 ps-2.5 pe-1.5 text-base sm:min-h-7 sm:text-sm",
+      },
+    },
+  },
+);
+
+type SelectTriggerProps = SelectPrimitive.Trigger.Props &
+  VariantProps<typeof selectTriggerVariants>;
 
 export function SelectTrigger({
   className,
   children,
+  size,
   ...props
-}: SelectPrimitive.Trigger.Props & { size?: "sm" }): ReactElement {
+}: SelectTriggerProps): ReactElement {
   return (
     <SelectPrimitive.Trigger
-      className={cn(triggerClassName, className)}
+      className={cn(selectTriggerVariants({ className, size }))}
       data-slot="select-trigger"
       {...props}
     >
@@ -82,29 +143,26 @@ export function SelectPopup({
         sideOffset={sideOffset}
       >
         <SelectPrimitive.Popup
-          className="origin-(--transform-origin) text-foreground outline-none"
+          className={selectPopupVariants()}
           data-slot="select-popup"
           {...props}
         >
           <SelectPrimitive.ScrollUpArrow
-            className="top-0 z-50 flex h-6 w-full cursor-default items-center justify-center before:pointer-events-none before:absolute before:inset-x-px before:top-px before:h-[200%] before:rounded-t-[calc(var(--radius-lg)-1px)] before:bg-linear-to-b before:from-50% before:from-popover"
+            className={selectScrollArrowVariants({ direction: "up" })}
             data-slot="select-scroll-up-arrow"
           >
             <ChevronUpIcon className="relative size-4.5 sm:size-4" />
           </SelectPrimitive.ScrollUpArrow>
-          <div className="relative h-full min-w-(--anchor-width) rounded-lg border bg-popover not-dark:bg-clip-padding shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]">
+          <div className={selectSurfaceVariants()}>
             <SelectPrimitive.List
-              className={cn(
-                "max-h-(--available-height) overflow-y-auto p-1",
-                className,
-              )}
+              className={cn(selectListVariants(), className)}
               data-slot="select-list"
             >
               {children}
             </SelectPrimitive.List>
           </div>
           <SelectPrimitive.ScrollDownArrow
-            className="bottom-0 z-50 flex h-6 w-full cursor-default items-center justify-center before:pointer-events-none before:absolute before:inset-x-px before:bottom-px before:h-[200%] before:rounded-b-[calc(var(--radius-lg)-1px)] before:bg-linear-to-t before:from-50% before:from-popover"
+            className={selectScrollArrowVariants({ direction: "down" })}
             data-slot="select-scroll-down-arrow"
           >
             <ChevronDownIcon className="relative size-4.5 sm:size-4" />
@@ -122,14 +180,14 @@ export function SelectItem({
 }: SelectPrimitive.Item.Props): ReactElement {
   return (
     <SelectPrimitive.Item
-      className={cn(
-        "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm py-1 ps-2 pe-4 text-base outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
-      )}
+      className={cn(selectItemVariants(), className)}
       data-slot="select-item"
       {...props}
     >
-      <SelectPrimitive.ItemIndicator className="col-start-1">
+      <SelectPrimitive.ItemText className="col-start-1 min-w-0">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator className="col-start-2 justify-self-end">
         <svg
           aria-hidden="true"
           fill="none"
@@ -145,9 +203,6 @@ export function SelectItem({
           <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
         </svg>
       </SelectPrimitive.ItemIndicator>
-      <SelectPrimitive.ItemText className="col-start-2 min-w-0">
-        {children}
-      </SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
   );
 }

--- a/apps/web/src/components/ui/surface-variants.ts
+++ b/apps/web/src/components/ui/surface-variants.ts
@@ -1,0 +1,21 @@
+import { cva } from "class-variance-authority";
+
+export const surfaceVariants = cva(
+  "border border-border bg-toolbar text-card-foreground backdrop-blur-[16px] shadow-[inset_0_1px_0_rgba(255,255,255,0.07),0_18px_48px_rgba(0,0,0,0.24),0_2px_10px_rgba(0,0,0,0.18)]",
+  {
+    defaultVariants: {
+      padding: "none",
+      radius: "xl",
+    },
+    variants: {
+      padding: {
+        none: "",
+        sm: "p-3",
+        toolbar: "p-1",
+      },
+      radius: {
+        xl: "rounded-xl",
+      },
+    },
+  },
+);

--- a/apps/web/src/components/ui/surface.tsx
+++ b/apps/web/src/components/ui/surface.tsx
@@ -1,0 +1,22 @@
+import type { VariantProps } from "class-variance-authority";
+import type { ComponentProps, ReactElement } from "react";
+import { cn } from "@/lib/utils";
+import { surfaceVariants } from "./surface-variants";
+
+type SurfaceProps = ComponentProps<"div"> &
+  VariantProps<typeof surfaceVariants>;
+
+export function Surface({
+  className,
+  padding,
+  radius,
+  ...props
+}: SurfaceProps): ReactElement {
+  return (
+    <div
+      className={cn(surfaceVariants({ className, padding, radius }))}
+      data-slot="surface"
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/toolbar.tsx
+++ b/apps/web/src/components/ui/toolbar.tsx
@@ -3,6 +3,7 @@
 import { Toolbar as ToolbarPrimitive } from "@base-ui/react/toolbar";
 import type { ReactElement } from "react";
 import { cn } from "@/lib/utils";
+import { surfaceVariants } from "./surface-variants";
 
 export function Toolbar({
   className,
@@ -11,7 +12,8 @@ export function Toolbar({
   return (
     <ToolbarPrimitive.Root
       className={cn(
-        "relative flex gap-2 rounded-xl border bg-card not-dark:bg-clip-padding p-1 text-card-foreground",
+        surfaceVariants({ padding: "toolbar" }),
+        "relative flex gap-2",
         className,
       )}
       data-slot="toolbar"

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import { cva } from "class-variance-authority";
 import type { ReactElement } from "react";
 import { cn } from "@/lib/utils";
 
@@ -10,6 +11,10 @@ export const TooltipProvider: typeof TooltipPrimitive.Provider =
 export const TooltipTrigger: typeof TooltipPrimitive.Trigger =
   TooltipPrimitive.Trigger;
 export const TooltipCreateHandle = TooltipPrimitive.createHandle;
+
+const tooltipPopupVariants = cva(
+  "max-w-64 origin-(--transform-origin) rounded-md border bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-lg/5 outline-none transition-[opacity,scale] duration-125 ease-[cubic-bezier(0.23,1,0.32,1)] data-[ending-style]:scale-95 data-[starting-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 data-[instant]:transition-none motion-reduce:transition-none",
+);
 
 export function TooltipPopup({
   className,
@@ -41,10 +46,7 @@ export function TooltipPopup({
         sideOffset={sideOffset}
       >
         <TooltipPrimitive.Popup
-          className={cn(
-            "max-w-64 rounded-md border bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-lg/5 outline-none",
-            className,
-          )}
+          className={cn(tooltipPopupVariants(), className)}
           data-slot="tooltip-popup"
           {...props}
         >

--- a/apps/web/src/routes/globals.css
+++ b/apps/web/src/routes/globals.css
@@ -114,8 +114,7 @@ body {
 
   --spacing-stage-content: 100rem;
   --spacing-action: 2.25rem;
-  --spacing-control-center: 2.5rem;
-  --spacing-control-select: 12.5rem;
+  --spacing-control-center: 2.75rem;
   --spacing-dev-panel: 18rem;
 
   --radius-md: calc(var(--radius) * 0.8);
@@ -152,7 +151,7 @@ body {
 @layer components {
   .stage-frame {
     width: min(
-      100%,
+      calc(100svw - 2rem),
       var(--spacing-stage-content),
       calc((100svh - var(--stage-page-chrome)) * 16 / 9)
     );

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -34,15 +34,6 @@ function Home() {
           target="_blank"
         >
           Aadi Sanghvi
-        </a>{" "}
-        and{" "}
-        <a
-          className="text-foreground transition-colors hover:text-muted-foreground"
-          href="https://www.linkedin.com/in/shiven-velagapudi/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Shiven Velagapudi
         </a>
       </footer>
     </div>


### PR DESCRIPTION
Refactors the web UI primitives around shared button, select, tooltip, empty, and surface variants so controls compose consistent design-system APIs. Polishes the stream toolbar and camera selector to avoid layout jumps, trim camera labels, preserve compact controls, and improve idle/stage presentation. Removes the extra footer credit. Validated with `pnpm --dir apps/web build` and `npx -y react-doctor@latest apps/web --verbose --diff`.