### PR TITLE
[codex] stabilize recognition decoding

### DIFF
--- a/apps/inference/src/inference/ctc.py
+++ b/apps/inference/src/inference/ctc.py
@@ -26,6 +26,10 @@ class CtcDecoderConfig:
     alpha: float
     beta: float
     unk_score_offset: float
+    beam_width: int = 50
+    beam_prune_logp: float = -10.0
+    token_min_logp: float = -5.0
+    confidence_temperature: float = 1.2
 
     @classmethod
     def from_env(cls) -> CtcDecoderConfig:
@@ -33,9 +37,13 @@ class CtcDecoderConfig:
         return cls(
             kenlm_model_path=model_path,
             unigram_path=_env_path("KENLM_UNIGRAMS_PATH", DEFAULT_UNIGRAMS_PATH),
-            alpha=_env_float("CTC_ALPHA", 0.65),
+            alpha=_env_float("CTC_ALPHA", 1.2),
             beta=_env_float("CTC_BETA", 2.0),
             unk_score_offset=_env_float("CTC_UNK_SCORE_OFFSET", -10.0),
+            beam_width=_env_int("CTC_BEAM_WIDTH", 50),
+            beam_prune_logp=_env_float("CTC_BEAM_PRUNE_LOGP", -10.0),
+            token_min_logp=_env_float("CTC_TOKEN_MIN_LOGP", -5.0),
+            confidence_temperature=_env_float("CTC_CONFIDENCE_TEMPERATURE", 1.2),
         )
 
 
@@ -154,12 +162,17 @@ def decode_alternatives(
     decoder: CtcDecoder,
     emissions: np.ndarray,
     beam_width: int,
+    beam_prune_logp: float = -10.0,
+    token_min_logp: float = -5.0,
+    confidence_temperature: float = 1.0,
 ) -> tuple[DecodedAlternative, ...]:
+    if confidence_temperature <= 0:
+        raise ValueError("confidence_temperature must be positive")
     beams = decoder.decode_beams(
         emissions,
         beam_width=beam_width,
-        beam_prune_logp=-10.0,
-        token_min_logp=-5.0,
+        beam_prune_logp=beam_prune_logp,
+        token_min_logp=token_min_logp,
     )
     scored: list[tuple[str, float, float, float, tuple[DecodedSpan, ...]]] = []
     for beam in beams:
@@ -170,7 +183,12 @@ def decode_alternatives(
         lm_score = beam_lm_score(beam)
         scored.append((text, logit_score + lm_score, logit_score, lm_score, beam_spans(beam)))
 
-    weights = softmax(np.asarray([score for _, score, *_ in scored], dtype=np.float64))
+    weights = softmax(
+        np.asarray(
+            [score / confidence_temperature for _, score, *_ in scored],
+            dtype=np.float64,
+        )
+    )
     alternatives: list[DecodedAlternative] = []
     seen: set[str] = set()
     for (text, _score, logit_score, lm_score, spans), confidence in sorted(
@@ -249,3 +267,8 @@ def _env_path(name: str, default: Path) -> Path | None:
 def _env_float(name: str, default: float) -> float:
     value = getenv(name)
     return float(value) if value else default
+
+
+def _env_int(name: str, default: int) -> int:
+    value = getenv(name)
+    return int(value) if value else default

--- a/apps/inference/src/inference/generated_schemas.py
+++ b/apps/inference/src/inference/generated_schemas.py
@@ -80,10 +80,13 @@ class RecognitionScored(BaseModel):
 class RecognitionState(BaseModel):
     display: RecognitionScored | None = None
     final_candidate: RecognitionScored | None = None
+    alternative_candidate: RecognitionScored | None = None
     selected_text: str
     selected_streak: int
     display_misses: int
     counts: list[RecognitionCount]
+    alternative_counts: list[RecognitionCount] | None = None
+    alternative_misses: int | None = None
 
 
 class RecognizeIn(BaseModel):

--- a/apps/inference/src/inference/model.py
+++ b/apps/inference/src/inference/model.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 from inference.ctc import DecodedText
 from inference.schemas import LandmarkFrame, Prediction, PredictOut, Span
+from inference.text_normalizer import normalize_prediction_text
 
 DEFAULT_MODELS_DIR = Path(__file__).resolve().parents[2] / "models"
 MODELS_DIR = Path(getenv("MODEL_DIR", str(DEFAULT_MODELS_DIR)))
+MODEL_CHECKPOINT_PATH_ENV = "MODEL_CHECKPOINT_PATH"
 
 
 class ModelBackend:
@@ -26,9 +28,15 @@ class CheckpointBackend(ModelBackend):
 
 def decoded_to_predict_out(decoded: DecodedText) -> PredictOut:
     best = decoded.alternatives[0] if decoded.alternatives else None
+    frame_confidence = (
+        decoded.confidence / best.confidence
+        if best is not None and best.confidence > 0
+        else 1.0
+    )
+    label = normalize_prediction_text(decoded.text)
     return PredictOut(
         prediction=Prediction(
-            label=decoded.text,
+            label=label,
             confidence=decoded.confidence,
             logit_score=best.logit_score if best else None,
             lm_score=best.lm_score if best else None,
@@ -37,7 +45,7 @@ def decoded_to_predict_out(decoded: DecodedText) -> PredictOut:
         alternatives=[
             Prediction(
                 label=item.text,
-                confidence=item.confidence,
+                confidence=item.confidence * frame_confidence,
                 logit_score=item.logit_score,
                 lm_score=item.lm_score,
                 raw_label=item.raw_text,
@@ -56,7 +64,7 @@ def decoded_to_predict_out(decoded: DecodedText) -> PredictOut:
         blank_ratio=decoded.blank_ratio,
         tail_blank_ratio=decoded.tail_blank_ratio,
         tail_blank_frames=decoded.tail_blank_frames,
-        partial_text=decoded.text,
+        partial_text=label,
         stable_text="",
     )
 
@@ -66,6 +74,13 @@ def load_backend() -> ModelBackend:
 
 
 def resolve_checkpoint_path(models_dir: Path = MODELS_DIR) -> Path:
+    explicit = getenv(MODEL_CHECKPOINT_PATH_ENV)
+    if explicit:
+        checkpoint = Path(explicit)
+        if not checkpoint.exists():
+            raise FileNotFoundError(f"checkpoint not found: {checkpoint}")
+        return checkpoint
+
     checkpoints = sorted(models_dir.glob("*.ckpt"))
     if not checkpoints:
         raise FileNotFoundError(f"expected one .ckpt model under {models_dir}")

--- a/apps/inference/src/inference/recognition.py
+++ b/apps/inference/src/inference/recognition.py
@@ -22,6 +22,7 @@ from inference.schemas import (
     RecognizeIn,
     RecognizeOut,
 )
+from inference.text_normalizer import is_uncorrected_oov, normalize_prediction_text
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +32,31 @@ class SmoothConfig:
     display_confidence: float = 0.06
     display_streak: int = 2
     display_count: int = 2
+    display_clear_misses: int = 2
+    display_clear_motion: float = 0.003
     instant_display_confidence: float = 0.45
-    commit_confidence: float = 0.14
+    commit_confidence: float = 0.85
+    short_commit_confidence: float = 0.96
     commit_streak: int = 3
     commit_count: int = 3
-    replace_margin: float = 0.08
+    endpoint_commit_count: int = 2
+    commit_soft_oov_min_chars: int = 6
+    commit_soft_oov_confidence: float = 0.95
+    commit_reject_uncorrected_oov_chars: int = 7
+    stable_commit_confidence: float = 0.8
+    stable_commit_count: int = 10
+    stable_commit_streak: int = 10
+    stable_commit_min_chars: int = 4
+    short_stable_commit_confidence: float = 0.8
+    short_stable_commit_count: int = 12
+    short_stable_commit_streak: int = 12
+    short_stable_commit_min_chars: int = 2
+    short_stable_commit_max_chars: int = 3
+    alternative_commit_confidence: float = 0.25
+    alternative_commit_count: int = 20
+    alternative_commit_min_chars: int = 4
+    alternative_commit_recent_misses: int = 5
+    replace_margin: float = 0.0
 
     @classmethod
     def from_env(cls) -> SmoothConfig:
@@ -43,12 +64,86 @@ class SmoothConfig:
             display_confidence=_env_float("DISPLAY_MIN_CONFIDENCE", cls.display_confidence),
             display_streak=_env_int("DISPLAY_MIN_STREAK", cls.display_streak),
             display_count=_env_int("DISPLAY_MIN_COUNT", cls.display_count),
+            display_clear_misses=_env_int("DISPLAY_CLEAR_MISSES", cls.display_clear_misses),
+            display_clear_motion=_env_float("DISPLAY_CLEAR_MOTION", cls.display_clear_motion),
             instant_display_confidence=_env_float(
                 "DISPLAY_INSTANT_CONFIDENCE", cls.instant_display_confidence
             ),
             commit_confidence=_env_float("COMMIT_MIN_CONFIDENCE", cls.commit_confidence),
+            short_commit_confidence=_env_float(
+                "SHORT_COMMIT_MIN_CONFIDENCE",
+                cls.short_commit_confidence,
+            ),
             commit_streak=_env_int("COMMIT_MIN_STREAK", cls.commit_streak),
             commit_count=_env_int("COMMIT_MIN_COUNT", cls.commit_count),
+            endpoint_commit_count=_env_int(
+                "ENDPOINT_COMMIT_MIN_COUNT",
+                cls.endpoint_commit_count,
+            ),
+            commit_soft_oov_min_chars=_env_int(
+                "COMMIT_SOFT_OOV_MIN_CHARS",
+                cls.commit_soft_oov_min_chars,
+            ),
+            commit_soft_oov_confidence=_env_float(
+                "COMMIT_SOFT_OOV_MIN_CONFIDENCE",
+                cls.commit_soft_oov_confidence,
+            ),
+            commit_reject_uncorrected_oov_chars=_env_int(
+                "COMMIT_REJECT_UNCORRECTED_OOV_CHARS",
+                cls.commit_reject_uncorrected_oov_chars,
+            ),
+            stable_commit_confidence=_env_float(
+                "STABLE_COMMIT_MIN_CONFIDENCE",
+                cls.stable_commit_confidence,
+            ),
+            stable_commit_count=_env_int(
+                "STABLE_COMMIT_MIN_COUNT",
+                cls.stable_commit_count,
+            ),
+            stable_commit_streak=_env_int(
+                "STABLE_COMMIT_MIN_STREAK",
+                cls.stable_commit_streak,
+            ),
+            stable_commit_min_chars=_env_int(
+                "STABLE_COMMIT_MIN_CHARS",
+                cls.stable_commit_min_chars,
+            ),
+            short_stable_commit_confidence=_env_float(
+                "SHORT_STABLE_COMMIT_MIN_CONFIDENCE",
+                cls.short_stable_commit_confidence,
+            ),
+            short_stable_commit_count=_env_int(
+                "SHORT_STABLE_COMMIT_MIN_COUNT",
+                cls.short_stable_commit_count,
+            ),
+            short_stable_commit_streak=_env_int(
+                "SHORT_STABLE_COMMIT_MIN_STREAK",
+                cls.short_stable_commit_streak,
+            ),
+            short_stable_commit_min_chars=_env_int(
+                "SHORT_STABLE_COMMIT_MIN_CHARS",
+                cls.short_stable_commit_min_chars,
+            ),
+            short_stable_commit_max_chars=_env_int(
+                "SHORT_STABLE_COMMIT_MAX_CHARS",
+                cls.short_stable_commit_max_chars,
+            ),
+            alternative_commit_confidence=_env_float(
+                "ALTERNATIVE_COMMIT_MIN_CONFIDENCE",
+                cls.alternative_commit_confidence,
+            ),
+            alternative_commit_count=_env_int(
+                "ALTERNATIVE_COMMIT_MIN_COUNT",
+                cls.alternative_commit_count,
+            ),
+            alternative_commit_min_chars=_env_int(
+                "ALTERNATIVE_COMMIT_MIN_CHARS",
+                cls.alternative_commit_min_chars,
+            ),
+            alternative_commit_recent_misses=_env_int(
+                "ALTERNATIVE_COMMIT_RECENT_MISSES",
+                cls.alternative_commit_recent_misses,
+            ),
             replace_margin=_env_float("DISPLAY_REPLACE_MARGIN", cls.replace_margin),
         )
 
@@ -57,10 +152,13 @@ def empty_state() -> RecognitionState:
     return RecognitionState(
         display=None,
         final_candidate=None,
+        alternative_candidate=None,
         selected_text="",
         selected_streak=0,
         display_misses=0,
         counts=[],
+        alternative_counts=[],
+        alternative_misses=0,
     )
 
 
@@ -68,7 +166,31 @@ async def recognize(payload: RecognizeIn, backend: ModelBackend) -> RecognizeOut
     config = SmoothConfig.from_env()
     state = payload.state or empty_state()
     if payload.finalize:
-        return finalize(state, payload.context, config)
+        prediction = None
+        decode = None
+        frames = list(payload.frames or [])
+        if frames and payload.state is not None:
+            started = perf_counter()
+            prediction = await backend.predict_frames(frames)
+            latency_ms = (perf_counter() - started) * 1_000
+            state, decode = accept_endpoint_prediction(
+                state,
+                prediction,
+                payload.context,
+                len(frames),
+                latency_ms,
+                config,
+            )
+        out = finalize(state, payload.context, config)
+        return out.model_copy(
+            update={
+                "trace": RecognitionTrace(
+                    prediction=prediction,
+                    decode=decode,
+                    finalize=out.trace.finalize,
+                )
+            }
+        )
 
     frames = list(payload.frames or [])
     if not frames:
@@ -105,6 +227,9 @@ def accept_prediction(
     text = clean(response.prediction.label)
     if text:
         state = accept_text(state, response, text, config)
+    else:
+        state = accept_blank(state, context, config)
+    state = accept_alternative_predictions(state, response, config)
 
     display_text = state.display.prediction.label if state.display else ""
     trace = DecodeTrace(
@@ -136,18 +261,64 @@ def accept_prediction(
     )
 
 
+def accept_endpoint_prediction(
+    state: RecognitionState,
+    response: PredictOut,
+    context: RecognitionContext,
+    buffered_frames: int,
+    latency_ms: float,
+    config: SmoothConfig | None = None,
+) -> tuple[RecognitionState, DecodeTrace]:
+    config = config or SmoothConfig.from_env()
+    state = state.model_copy(deep=True)
+    text = clean(response.prediction.label)
+    trace = DecodeTrace(
+        buffered_frames=buffered_frames,
+        input_text=clean(response.prediction.raw_label or response.prediction.label),
+        display_text=state.display.prediction.label if state.display else "",
+        idle_frames=context.idle_frames,
+        motion=context.motion,
+        latency_ms=latency_ms,
+    )
+    if not should_accept_endpoint(text, response.prediction.confidence, state, config):
+        return state, trace
+
+    seen = count_for(state, text) + 1
+    state.counts = set_count(state.counts, text, max(seen, config.commit_count))
+    scored = RecognitionScored(
+        prediction=Prediction(
+            label=text,
+            confidence=response.prediction.confidence,
+            logit_score=response.prediction.logit_score,
+            lm_score=response.prediction.lm_score,
+            raw_label=clean(response.prediction.raw_label or text),
+        ),
+        score=(
+            response.prediction.confidence
+            + min(seen, 5) * 0.05
+            + min(config.commit_streak, 4) * 0.05
+        ),
+        source="endpoint",
+        lm_score=response.prediction.lm_score,
+        model_agrees=clean(response.greedy_text) == text,
+        streak=config.commit_streak,
+    )
+    state.final_candidate = pick_final(state.final_candidate, scored, seen, config)
+    return state, trace
+
+
 def finalize(
     state: RecognitionState,
     context: RecognitionContext,
     config: SmoothConfig | None = None,
 ) -> RecognizeOut:
     config = config or SmoothConfig.from_env()
-    selected = state.final_candidate or state.display
+    selected = select_final(state, config)
     prediction = None
     committed = False
     if selected:
         prediction = selected.prediction
-        committed = should_commit(selected, count_for(state, prediction.label), config)
+        committed = should_commit(selected, count_for_candidate(state, selected), config)
     display = prediction if committed else None
     reason = context.endpoint_reason or EndpointReason.idle
     trace = FinalizeTrace(
@@ -212,9 +383,161 @@ def accept_text(
     if should_display(scored, state.display, seen, streak, misses, config):
         state.display = scored
         state.display_misses = 0
+    elif should_clear_display(scored, state.display, misses, config):
+        if state.final_candidate and not compatible_text(
+            state.final_candidate.prediction.label,
+            scored.prediction.label,
+        ):
+            state.final_candidate = None
+        state.display = None
+        state.display_misses = 0
     else:
         state.display_misses = misses
     return state
+
+
+def accept_blank(
+    state: RecognitionState,
+    context: RecognitionContext,
+    config: SmoothConfig,
+) -> RecognitionState:
+    if not state.display:
+        return state
+    misses = state.display_misses + 1
+    if (
+        misses >= config.display_clear_misses
+        and context.idle_frames == 0
+        and context.motion >= config.display_clear_motion
+    ):
+        state.display = None
+        state.final_candidate = None
+        state.alternative_candidate = None
+        state.alternative_misses = 0
+        state.display_misses = 0
+    else:
+        state.display_misses = misses
+    return state
+
+
+def accept_alternative_predictions(
+    state: RecognitionState,
+    response: PredictOut,
+    config: SmoothConfig,
+) -> RecognitionState:
+    candidates = ranked_current_candidates(response)
+    present = {text for text, _, _ in candidates}
+    state = age_alternative_candidate(state, present, config)
+    counts = list(state.alternative_counts or [])
+
+    for text, prediction, rank in candidates:
+        seen = count_in(counts, text) + 1
+        counts = set_count(counts, text, seen)
+        scored = alternative_scored(response, prediction, text, seen, rank)
+        if should_remember_alternative_candidate(scored, seen, rank, config):
+            state.alternative_candidate = pick_alternative_candidate(
+                state.alternative_candidate,
+                scored,
+                config,
+            )
+            state.alternative_misses = 0
+
+    state.alternative_counts = counts
+    return state
+
+
+def ranked_current_candidates(response: PredictOut) -> tuple[tuple[str, Prediction, int], ...]:
+    best_by_text: dict[str, tuple[Prediction, int]] = {}
+    for rank, prediction in enumerate((response.prediction, *response.alternatives)):
+        text = clean(normalize_prediction_text(prediction.label))
+        if not text:
+            continue
+        current = best_by_text.get(text)
+        if current is None:
+            best_by_text[text] = (prediction, rank)
+            continue
+        best_prediction, best_rank = current
+        best_by_text[text] = (
+            prediction if prediction.confidence > best_prediction.confidence else best_prediction,
+            min(rank, best_rank),
+        )
+    return tuple((text, prediction, rank) for text, (prediction, rank) in best_by_text.items())
+
+
+def age_alternative_candidate(
+    state: RecognitionState,
+    present: set[str],
+    config: SmoothConfig,
+) -> RecognitionState:
+    if state.alternative_candidate is None:
+        state.alternative_misses = 0
+        return state
+    if state.alternative_candidate.prediction.label in present:
+        state.alternative_misses = 0
+        return state
+
+    misses = (state.alternative_misses or 0) + 1
+    if misses > config.alternative_commit_recent_misses:
+        state.alternative_candidate = None
+        state.alternative_misses = 0
+    else:
+        state.alternative_misses = misses
+    return state
+
+
+def alternative_scored(
+    response: PredictOut,
+    prediction: Prediction,
+    text: str,
+    seen: int,
+    rank: int,
+) -> RecognitionScored:
+    return RecognitionScored(
+        prediction=Prediction(
+            label=text,
+            confidence=prediction.confidence,
+            logit_score=prediction.logit_score,
+            lm_score=prediction.lm_score,
+            raw_label=clean(prediction.raw_label or prediction.label),
+        ),
+        score=prediction.confidence + min(seen, 20) * 0.06 - rank * 0.02,
+        source="alternative",
+        lm_score=prediction.lm_score,
+        model_agrees=clean(response.greedy_text) == text,
+        streak=seen,
+    )
+
+
+def should_remember_alternative_candidate(
+    candidate: RecognitionScored,
+    seen: int,
+    rank: int,
+    config: SmoothConfig,
+) -> bool:
+    text = candidate.prediction.label
+    text_len = len(clean(text).replace(" ", ""))
+    return (
+        rank == 0
+        and text_len >= config.alternative_commit_min_chars
+        and seen >= config.alternative_commit_count
+        and candidate.prediction.confidence >= config.alternative_commit_confidence
+        and not is_uncorrected_oov(
+            text,
+            min_chars=config.commit_reject_uncorrected_oov_chars,
+        )
+        and not is_low_confidence_soft_oov(text, candidate.prediction.confidence, config)
+    )
+
+
+def pick_alternative_candidate(
+    current: RecognitionScored | None,
+    candidate: RecognitionScored,
+    config: SmoothConfig,
+) -> RecognitionScored:
+    if current is None:
+        return candidate
+    if current.prediction.label == candidate.prediction.label:
+        return merge_same(current, candidate)
+    return candidate if candidate.score > current.score + config.replace_margin else current
 
 
 def should_display(
@@ -233,9 +556,24 @@ def should_display(
     )
     if display is None:
         return stable or confidence >= config.instant_display_confidence
-    if not stable and misses < 3:
+    if not stable:
         return False
+    if misses >= config.display_clear_misses:
+        return True
     return confidence >= display.prediction.confidence + config.replace_margin
+
+
+def should_clear_display(
+    candidate: RecognitionScored,
+    display: RecognitionScored | None,
+    misses: int,
+    config: SmoothConfig,
+) -> bool:
+    if display is None or misses < config.display_clear_misses:
+        return False
+    if candidate.prediction.confidence < config.display_confidence:
+        return False
+    return not compatible_text(display.prediction.label, candidate.prediction.label)
 
 
 def pick_final(
@@ -253,16 +591,153 @@ def pick_final(
     return candidate if candidate.score > current.score + config.replace_margin else current
 
 
+def select_final(state: RecognitionState, config: SmoothConfig) -> RecognitionScored | None:
+    selected = select_primary_final(state, config)
+    if selected and should_commit(selected, count_for_candidate(state, selected), config):
+        return selected
+    alternative = state.alternative_candidate
+    if alternative and should_commit(
+        alternative,
+        count_for_candidate(state, alternative),
+        config,
+    ):
+        return alternative
+    return selected
+
+
+def select_primary_final(
+    state: RecognitionState,
+    config: SmoothConfig,
+) -> RecognitionScored | None:
+    selected = state.final_candidate
+    display = state.display
+    if selected is None:
+        return display
+    if display is None:
+        return selected
+    if selected.prediction.label == display.prediction.label:
+        return merge_same(selected, display)
+    if not should_commit(display, count_for(state, display.prediction.label), config):
+        return selected
+    if not compatible_text(selected.prediction.label, display.prediction.label):
+        return display
+    if display.score > selected.score + config.replace_margin:
+        return display
+    return selected
+
+
 def should_commit(
     candidate: RecognitionScored,
     seen: int,
     config: SmoothConfig | None = None,
 ) -> bool:
     config = config or SmoothConfig.from_env()
+    text_len = len(clean(candidate.prediction.label).replace(" ", ""))
+    confidence = max(
+        config.commit_confidence,
+        config.short_commit_confidence if 0 < text_len <= 3 else config.commit_confidence,
+    )
+    confidence_gate = candidate.prediction.confidence >= confidence
+    stable_gate = is_stable_model_agreed_candidate(candidate, seen, config)
+    short_stable_gate = is_stable_short_model_agreed_candidate(candidate, seen, config)
+    alternative_gate = is_stable_alternative_candidate(candidate, seen, config)
     return (
-        candidate.prediction.confidence >= config.commit_confidence
+        (confidence_gate or stable_gate or short_stable_gate or alternative_gate)
         and seen >= config.commit_count
         and candidate.streak >= config.commit_streak
+        and not is_uncorrected_oov(
+            candidate.prediction.label,
+            min_chars=config.commit_reject_uncorrected_oov_chars,
+        )
+        and not is_low_confidence_soft_oov(
+            candidate.prediction.label,
+            candidate.prediction.confidence,
+            config,
+        )
+    )
+
+
+def is_stable_alternative_candidate(
+    candidate: RecognitionScored,
+    seen: int,
+    config: SmoothConfig,
+) -> bool:
+    text_len = len(clean(candidate.prediction.label).replace(" ", ""))
+    return (
+        candidate.source == "alternative"
+        and text_len >= config.alternative_commit_min_chars
+        and seen >= config.alternative_commit_count
+        and candidate.streak >= config.alternative_commit_count
+        and candidate.prediction.confidence >= config.alternative_commit_confidence
+    )
+
+
+def is_stable_short_model_agreed_candidate(
+    candidate: RecognitionScored,
+    seen: int,
+    config: SmoothConfig,
+) -> bool:
+    text_len = len(clean(candidate.prediction.label).replace(" ", ""))
+    return (
+        candidate.model_agrees
+        and config.short_stable_commit_min_chars
+        <= text_len
+        <= config.short_stable_commit_max_chars
+        and seen >= config.short_stable_commit_count
+        and candidate.streak >= config.short_stable_commit_streak
+        and candidate.prediction.confidence >= config.short_stable_commit_confidence
+    )
+
+
+def is_stable_model_agreed_candidate(
+    candidate: RecognitionScored,
+    seen: int,
+    config: SmoothConfig,
+) -> bool:
+    text_len = len(clean(candidate.prediction.label).replace(" ", ""))
+    return (
+        candidate.model_agrees
+        and text_len >= config.stable_commit_min_chars
+        and seen >= config.stable_commit_count
+        and candidate.streak >= config.stable_commit_streak
+        and candidate.prediction.confidence >= config.stable_commit_confidence
+    )
+
+
+def should_accept_endpoint(
+    text: str,
+    confidence: float,
+    state: RecognitionState,
+    config: SmoothConfig,
+) -> bool:
+    if not text or count_for(state, text) < config.endpoint_commit_count:
+        return False
+    text_len = len(text.replace(" ", ""))
+    threshold = max(
+        config.commit_confidence,
+        config.short_commit_confidence if 0 < text_len <= 3 else config.commit_confidence,
+    )
+    return (
+        confidence >= threshold
+        and not is_uncorrected_oov(
+            text,
+            min_chars=config.commit_reject_uncorrected_oov_chars,
+        )
+        and not is_low_confidence_soft_oov(text, confidence, config)
+    )
+
+
+def is_low_confidence_soft_oov(
+    text: str,
+    confidence: float,
+    config: SmoothConfig,
+) -> bool:
+    return (
+        confidence < config.commit_soft_oov_confidence
+        and is_uncorrected_oov(
+            text,
+            min_chars=config.commit_soft_oov_min_chars,
+        )
     )
 
 
@@ -290,8 +765,39 @@ def clean(text: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9 ]+", "", text.lower())).strip()
 
 
+def compatible_text(left: str, right: str) -> bool:
+    left = clean(left).replace(" ", "")
+    right = clean(right).replace(" ", "")
+    if not left or not right:
+        return False
+    if left == right or left.rstrip("s") == right.rstrip("s"):
+        return True
+    if left.startswith(right) or right.startswith(left):
+        return True
+    return common_prefix_len(left, right) >= min(5, len(left), len(right))
+
+
+def common_prefix_len(left: str, right: str) -> int:
+    count = 0
+    for left_char, right_char in zip(left, right, strict=False):
+        if left_char != right_char:
+            break
+        count += 1
+    return count
+
+
 def count_for(state: RecognitionState, text: str) -> int:
-    for item in state.counts:
+    return count_in(state.counts, text)
+
+
+def count_for_candidate(state: RecognitionState, candidate: RecognitionScored) -> int:
+    if candidate.source == "alternative":
+        return count_in(state.alternative_counts or [], candidate.prediction.label)
+    return count_for(state, candidate.prediction.label)
+
+
+def count_in(counts: Sequence[RecognitionCount], text: str) -> int:
+    for item in counts:
         if item.text == text:
             return item.count
     return 0

--- a/apps/inference/src/inference/runtime.py
+++ b/apps/inference/src/inference/runtime.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateImportUsage=false
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -21,9 +22,20 @@ from inference.ctc import (
 )
 from inference.features import frames_to_features
 from inference.network import load_model, resolve_device, sequence_confidence
+from inference.text_normalizer import normalize_prediction_text
 
 if TYPE_CHECKING:
     from inference.schemas import LandmarkFrame
+
+
+@dataclass(frozen=True)
+class RuntimeEmission:
+    emissions: np.ndarray
+    greedy_text: str
+    blank_ratio: float
+    tail_blank_ratio: float
+    tail_blank_frames: int
+    frame_confidence: float
 
 
 class HandwaveRuntime:
@@ -33,38 +45,62 @@ class HandwaveRuntime:
         device: str = "auto",
         decoder_config: CtcDecoderConfig | None = None,
     ) -> None:
+        decoder_config = decoder_config or CtcDecoderConfig.from_env()
         self.device = resolve_device(device)
         self.model = load_model(Path(checkpoint_path), self.device, vocab_size=len(VOCAB))
         self.decoder = build_decoder(decoder_config)
-        self.beam_width = 50
+        self.beam_width = decoder_config.beam_width
+        self.beam_prune_logp = decoder_config.beam_prune_logp
+        self.token_min_logp = decoder_config.token_min_logp
+        self.confidence_temperature = decoder_config.confidence_temperature
         self.allowed_token_ids = allowed_token_ids("abcdefghijklmnopqrstuvwxyz ")
 
     @torch.no_grad()
     def predict(self, frames: list[LandmarkFrame]) -> DecodedText:
+        return self.decode_emission(self.encode(frames))
+
+    @torch.no_grad()
+    def encode(self, frames: list[LandmarkFrame]) -> RuntimeEmission:
         features = frames_to_features(frames)
         tensor = torch.from_numpy(features).unsqueeze(0).to(self.device)
         lengths = torch.tensor([features.shape[0]], device=self.device)
         log_probs, input_lengths = self.model(tensor, lengths)
         emissions = single_emission(log_probs, input_lengths)
         emissions = mask_emissions(emissions, self.allowed_token_ids)
-        alternatives = self._decode(emissions)
-        greedy_text = greedy_decode(emissions)
         blanks = blank_stats(emissions)
-        frame_confidence = sequence_confidence(log_probs, input_lengths)[0]
-        best = alternatives[0] if alternatives else DecodedAlternative("", 0.0, 0.0, 0.0, "")
-        return DecodedText(
-            text=best.text,
-            confidence=best.confidence * frame_confidence,
-            alternatives=alternatives,
-            spans=best.spans,
-            greedy_text=greedy_text,
+        return RuntimeEmission(
+            emissions=emissions,
+            greedy_text=greedy_decode(emissions),
             blank_ratio=blanks.blank_ratio,
             tail_blank_ratio=blanks.tail_blank_ratio,
             tail_blank_frames=blanks.tail_blank_frames,
+            frame_confidence=sequence_confidence(log_probs, input_lengths)[0],
+        )
+
+    def decode_emission(self, emission: RuntimeEmission) -> DecodedText:
+        emissions = emission.emissions
+        alternatives = self._decode(emissions)
+        best = alternatives[0] if alternatives else DecodedAlternative("", 0.0, 0.0, 0.0, "")
+        return DecodedText(
+            text=normalize_prediction_text(best.text),
+            confidence=best.confidence * emission.frame_confidence,
+            alternatives=alternatives,
+            spans=best.spans,
+            greedy_text=emission.greedy_text,
+            blank_ratio=emission.blank_ratio,
+            tail_blank_ratio=emission.tail_blank_ratio,
+            tail_blank_frames=emission.tail_blank_frames,
         )
 
     def _decode(self, emissions: np.ndarray) -> tuple[DecodedAlternative, ...]:
-        return decode_alternatives(self.decoder, emissions, self.beam_width)
+        return decode_alternatives(
+            self.decoder,
+            emissions,
+            self.beam_width,
+            beam_prune_logp=getattr(self, "beam_prune_logp", -10.0),
+            token_min_logp=getattr(self, "token_min_logp", -5.0),
+            confidence_temperature=getattr(self, "confidence_temperature", 1.2),
+        )
 
 
 def single_emission(log_probs: torch.Tensor, input_lengths: torch.Tensor) -> np.ndarray:

--- a/apps/inference/src/inference/text_normalizer.py
+++ b/apps/inference/src/inference/text_normalizer.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import lru_cache
+from math import inf, log1p
+from typing import TYPE_CHECKING
+
+from inference.ctc import DEFAULT_KENLM_MODEL_PATH, DEFAULT_UNIGRAMS_PATH, load_unigrams
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+MAX_WORDS = 50_000
+MAX_WORD_LENGTH = 14
+MAX_SOURCE_SPAN = 12
+MAX_CANDIDATES_PER_SPAN = 64
+MAX_PATHS_PER_POSITION = 128
+MIN_CORRECTION_LENGTH = 6
+ACCEPT_SCORE = 5.6
+EXACT_SPLIT_ACCEPT_SCORE = 5.1
+SAFE_EXACT_OOV_SPLIT_SCORE = 6.1
+MIN_EXACT_SPLIT_WORDS = 3
+MAX_EXACT_SPLIT_WORDS = 5
+MAX_CORRECTION_WORDS = 5
+SHORT_FIRST_WORD_ACCEPT_SCORE = 4.9
+SHORT_FIRST_WORD_LENGTH = 3
+SHORT_FIRST_WORD_REPLACE_MARGIN = 0.35
+SPACED_CORRECTION_MARGIN = 0.18
+MAX_ONE_LETTER_WORDS = 1
+MAX_ONE_LETTER_SOURCE_RANK = 100
+MAX_SHORT_EXACT_WORD_RANK = 5_000
+MAX_SHORT_FIRST_WORD_RANK = 500
+MAX_SINGLE_WORD_CORRECTION_CHARS = 8
+MAX_SINGLE_WORD_CORRECTION_RANK = 1_000
+MIN_SINGLE_WORD_RANK_RATIO = 2.5
+MIN_COMPOUND_COLLAPSE_RANK = 1_000
+
+
+@dataclass(frozen=True)
+class WordCandidate:
+    word: str
+    edits: int
+
+
+@dataclass(frozen=True)
+class SegmentationPath:
+    base_cost: float
+    edits: int
+    words: tuple[str, ...]
+
+
+class TextNormalizer:
+    def __init__(self) -> None:
+        self.words, self.ranks = ranked_words(load_unigrams(DEFAULT_UNIGRAMS_PATH))
+        self.word_set = set(self.words)
+        self.delete_index = deletion_index(self.words)
+        self.language_model = load_language_model()
+        self._candidate_cache: dict[str, tuple[WordCandidate, ...]] = {}
+
+    def normalize(self, text: str) -> str:
+        raw = letters_only(text)
+        if not raw:
+            return text
+        if " " in text:
+            return self.normalize_spaced(text, raw)
+        if raw in self.word_set:
+            return text
+
+        corrected_word = self.single_word_correction(raw)
+        if corrected_word is not None:
+            return corrected_word
+        exact_split = self.best_exact_split(raw)
+        if exact_split is not None:
+            return self.refine_spaced_candidate(exact_split.words)
+        if len(raw) < MIN_CORRECTION_LENGTH:
+            return text
+
+        candidates = self.correction_candidates(raw)
+        if not candidates:
+            return text
+        best_score, best = candidates[0]
+        short_first = self.short_first_word_correction(raw)
+        if (
+            short_first is not None
+            and self.path_score(short_first) + SHORT_FIRST_WORD_REPLACE_MARGIN < best_score
+        ):
+            return self.refine_spaced_candidate(short_first.words)
+        if best_score >= ACCEPT_SCORE:
+            return self.refine_spaced_candidate(short_first.words) if short_first else text
+        exact_score = self.best_exact_split_score(raw)
+        if exact_score is not None and best_score >= exact_score:
+            return text
+        return self.refine_spaced_candidate(best.words)
+
+    def normalize_spaced(self, text: str, raw: str) -> str:
+        words = tuple(letters_only(part) for part in text.split())
+        words = tuple(word for word in words if word)
+        if not words:
+            return text
+        if raw in self.word_set and should_collapse_split_compound(raw, words, self.ranks):
+            return raw
+        if raw in self.word_set and any(word not in self.word_set for word in words):
+            return raw
+
+        current_score = self.words_score(words)
+        candidates = [
+            item for item in self.correction_candidates(raw) if len(item[1].words) == len(words)
+        ]
+        exact_split = self.best_exact_split(raw)
+        if exact_split is not None and len(exact_split.words) == len(words):
+            candidates.append((self.path_score(exact_split), exact_split))
+        if not candidates:
+            return text
+
+        best_score, best = min(candidates, key=lambda item: item[0])
+        if best_score + SPACED_CORRECTION_MARGIN >= current_score:
+            return text
+        return " ".join(best.words)
+
+    def refine_spaced_candidate(self, words: tuple[str, ...]) -> str:
+        text = " ".join(words)
+        if len(words) <= 1:
+            return text
+        return self.normalize_spaced(text, letters_only(text))
+
+    def correction_candidates(self, raw: str) -> tuple[tuple[float, SegmentationPath], ...]:
+        max_edits = 2 if len(raw) >= 7 else 1
+        scored: list[tuple[float, SegmentationPath]] = []
+        for path in self.segmentations(raw):
+            if len(path.words) < 2 or path.edits == 0 or path.edits > max_edits:
+                continue
+            if not plausible_phrase(path.words):
+                continue
+            if has_rare_short_word(path.words, self.ranks):
+                continue
+            if len(path.words) >= MAX_EXACT_SPLIT_WORDS and has_one_letter_word(path.words):
+                continue
+            if not preserves_edges(raw, path.words):
+                continue
+            scored.append((self.path_score(path), path))
+        return tuple(sorted(scored, key=lambda item: item[0]))
+
+    def short_first_word_correction(self, raw: str) -> SegmentationPath | None:
+        max_edits = 2 if len(raw) >= 7 else 1
+        scored: list[tuple[float, SegmentationPath]] = []
+        for path in self.segmentations(raw):
+            if len(path.words) < MIN_EXACT_SPLIT_WORDS:
+                continue
+            if path.edits == 0 or path.edits > max_edits:
+                continue
+            if not plausible_phrase(path.words):
+                continue
+            if has_rare_short_word(path.words, self.ranks):
+                continue
+            if len(path.words[0]) != SHORT_FIRST_WORD_LENGTH:
+                continue
+            if self.ranks[path.words[0]] > MAX_SHORT_FIRST_WORD_RANK:
+                continue
+            if not path.words[-1].endswith(raw[-1]):
+                continue
+            score = self.path_score(path)
+            if score <= SHORT_FIRST_WORD_ACCEPT_SCORE:
+                scored.append((score, path))
+        if not scored:
+            return None
+        return min(scored, key=short_first_word_score_key)[1]
+
+    def single_word_correction(self, raw: str) -> str | None:
+        if not (4 <= len(raw) <= MAX_SINGLE_WORD_CORRECTION_CHARS):
+            return None
+        if raw in self.word_set:
+            return None
+
+        candidates = [
+            candidate
+            for candidate in self.word_candidates(raw)
+            if (
+                candidate.edits == 1
+                and len(candidate.word) >= 4
+                and self.ranks[candidate.word] <= MAX_SINGLE_WORD_CORRECTION_RANK
+                and plausible_single_word_alignment(raw, candidate.word)
+            )
+        ]
+        if not candidates:
+            return None
+        best = candidates[0]
+        if len(candidates) == 1:
+            return best.word
+
+        second_rank = self.ranks[candidates[1].word]
+        if second_rank / self.ranks[best.word] >= MIN_SINGLE_WORD_RANK_RATIO:
+            return best.word
+        return None
+
+    def best_exact_split_score(self, raw: str) -> float | None:
+        path = self.best_exact_split(raw)
+        return self.path_score(path) if path is not None else None
+
+    def best_exact_split(self, raw: str) -> SegmentationPath | None:
+        candidates = [
+            path
+            for path in self.segmentations(raw)
+            if (
+                path.edits == 0
+                and len(path.words) >= MIN_EXACT_SPLIT_WORDS
+                and len(path.words) <= MAX_EXACT_SPLIT_WORDS
+                and plausible_phrase(path.words)
+                and not has_rare_short_word(path.words, self.ranks)
+                and preserves_edges(raw, path.words, min_first_word_len=2)
+            )
+        ]
+        if not candidates:
+            return None
+        best = min(candidates, key=self.path_score)
+        if self.path_score(best) >= EXACT_SPLIT_ACCEPT_SCORE:
+            return None
+        return best
+
+    def any_exact_split_score(self, raw: str) -> float | None:
+        scores = [
+            self.path_score(path)
+            for path in self.segmentations(raw)
+            if path.edits == 0 and len(path.words) > 1
+        ]
+        return min(scores) if scores else None
+
+    def words_score(self, words: tuple[str, ...]) -> float:
+        if not words or any(word not in self.ranks for word in words):
+            return inf
+        return self.path_score(SegmentationPath(base_cost=0.0, edits=0, words=words))
+
+    def path_score(self, path: SegmentationPath) -> float:
+        text = " ".join(path.words)
+        lm_cost = -self.language_model.score(text, bos=True, eos=True) / (len(path.words) + 1)
+        rank_cost = sum(log1p(self.ranks[word]) for word in path.words) / len(path.words)
+        return (
+            path.edits * 0.35
+            + lm_cost * 1.3
+            + rank_cost * 0.025
+            + len(path.words) * 0.03
+        )
+
+    def segmentations(self, raw: str) -> tuple[SegmentationPath, ...]:
+        size = len(raw)
+        paths: list[list[SegmentationPath]] = [[] for _ in range(size + 1)]
+        paths[0] = [SegmentationPath(base_cost=0.0, edits=0, words=())]
+
+        for start in range(size):
+            if not paths[start]:
+                continue
+            for path in paths[start]:
+                for end in range(start + 1, min(size, start + MAX_SOURCE_SPAN) + 1):
+                    source = raw[start:end]
+                    for candidate in self.word_candidates(source):
+                        rank = self.ranks[candidate.word]
+                        cost = (
+                            path.base_cost
+                            + candidate.edits * 0.5
+                            + log1p(rank) * 0.015
+                            + 0.02
+                        )
+                        paths[end].append(
+                            SegmentationPath(
+                                base_cost=cost,
+                                edits=path.edits + candidate.edits,
+                                words=(*path.words, candidate.word),
+                            )
+                        )
+            for end in range(start + 1, size + 1):
+                if len(paths[end]) > MAX_PATHS_PER_POSITION:
+                    paths[end] = sorted(paths[end], key=lambda item: item.base_cost)[
+                        :MAX_PATHS_PER_POSITION
+                    ]
+        return tuple(paths[size])
+
+    def word_candidates(self, source: str) -> tuple[WordCandidate, ...]:
+        cached = self._candidate_cache.get(source)
+        if cached is not None:
+            return cached
+        candidates: dict[str, int] = {}
+        if source in self.word_set:
+            candidates[source] = 0
+
+        keys = {source}
+        keys.update(source[:index] + source[index + 1 :] for index in range(len(source)))
+        for key in keys:
+            for word in self.delete_index.get(key, ()):
+                edits = edit_distance(source, word, max_distance=1)
+                if edits <= 1:
+                    candidates[word] = min(candidates.get(word, edits), edits)
+
+        result = tuple(
+            WordCandidate(word, edits)
+            for word, edits in sorted(
+                candidates.items(),
+                key=lambda item: (item[1], self.ranks[item[0]]),
+            )[:MAX_CANDIDATES_PER_SPAN]
+        )
+        if len(self._candidate_cache) >= 20_000:
+            self._candidate_cache.clear()
+        self._candidate_cache[source] = result
+        return result
+
+
+@lru_cache(maxsize=1)
+def default_normalizer() -> TextNormalizer | None:
+    try:
+        return TextNormalizer()
+    except (ImportError, OSError, ValueError):
+        return None
+
+
+def normalize_prediction_text(text: str) -> str:
+    normalizer = default_normalizer()
+    if normalizer is None:
+        return text
+    return normalizer.normalize(text)
+
+
+def is_uncorrected_oov(text: str, *, min_chars: int) -> bool:
+    if min_chars <= 0:
+        return False
+    normalizer = default_normalizer()
+    if normalizer is None:
+        return False
+
+    raw = letters_only(text)
+    if len(raw) < min_chars or " " in text or raw in normalizer.word_set:
+        return False
+    exact_score = normalizer.any_exact_split_score(raw)
+    if exact_score is not None and exact_score < SAFE_EXACT_OOV_SPLIT_SCORE:
+        return False
+
+    candidates = normalizer.correction_candidates(raw)
+    return bool(candidates and candidates[0][0] >= ACCEPT_SCORE)
+
+
+def ranked_words(raw_words: Iterable[str]) -> tuple[tuple[str, ...], dict[str, int]]:
+    words: list[str] = []
+    ranks: dict[str, int] = {}
+    for source_rank, word in enumerate(raw_words):
+        if not is_candidate_word(word, source_rank):
+            continue
+        if word in ranks:
+            continue
+        ranks[word] = len(ranks) + 1
+        words.append(word)
+        if len(words) >= MAX_WORDS:
+            break
+    return tuple(words), ranks
+
+
+def is_candidate_word(word: str, source_rank: int) -> bool:
+    if not word.isalpha() or not word.islower():
+        return False
+    if len(word) == 1:
+        return source_rank < MAX_ONE_LETTER_SOURCE_RANK
+    if len(word) == 2 and source_rank > 2_500:
+        return False
+    if len(word) == 3 and source_rank > 20_000:
+        return False
+    return len(word) <= MAX_WORD_LENGTH
+
+
+def deletion_index(words: Iterable[str]) -> dict[str, set[str]]:
+    index: dict[str, set[str]] = defaultdict(set)
+    for word in words:
+        if len(word) < 2:
+            continue
+        index[word].add(word)
+        for char_index in range(len(word)):
+            index[word[:char_index] + word[char_index + 1 :]].add(word)
+    return dict(index)
+
+
+def edit_distance(left: str, right: str, *, max_distance: int) -> int:
+    if abs(len(left) - len(right)) > max_distance:
+        return max_distance + 1
+    previous = list(range(len(right) + 1))
+    for row, left_char in enumerate(left, start=1):
+        current = [row]
+        row_min = row
+        for column, right_char in enumerate(right, start=1):
+            value = previous[column - 1] if left_char == right_char else previous[column - 1] + 1
+            value = min(value, previous[column] + 1, current[-1] + 1)
+            current.append(value)
+            row_min = min(row_min, value)
+        if row_min > max_distance:
+            return max_distance + 1
+        previous = current
+    return previous[-1]
+
+
+def letters_only(text: str) -> str:
+    return "".join(char for char in text.lower() if "a" <= char <= "z")
+
+
+def preserves_edges(
+    raw: str,
+    words: tuple[str, ...],
+    *,
+    min_first_word_len: int = 4,
+) -> bool:
+    return bool(
+        words
+        and words[0].startswith(raw[0])
+        and words[-1].endswith(raw[-1])
+        and len(words[0]) >= min_first_word_len
+    )
+
+
+def plausible_phrase(words: tuple[str, ...]) -> bool:
+    if len(words) > MAX_CORRECTION_WORDS:
+        return False
+    return sum(1 for word in words if len(word) == 1) <= MAX_ONE_LETTER_WORDS
+
+
+def has_rare_short_word(words: tuple[str, ...], ranks: dict[str, int]) -> bool:
+    return any(
+        1 < len(word) <= 3 and ranks.get(word, MAX_WORDS + 1) > MAX_SHORT_EXACT_WORD_RANK
+        for word in words
+    )
+
+
+def has_one_letter_word(words: tuple[str, ...]) -> bool:
+    return any(len(word) == 1 for word in words)
+
+
+def should_collapse_split_compound(
+    raw: str,
+    words: tuple[str, ...],
+    ranks: dict[str, int],
+) -> bool:
+    return (
+        len(words) == 2
+        and raw in ranks
+        and ranks[raw] >= MIN_COMPOUND_COLLAPSE_RANK
+        and all(word in ranks and len(word) >= 3 for word in words)
+    )
+
+
+def short_first_word_score_key(item: tuple[float, SegmentationPath]) -> tuple[float, int, int]:
+    score, path = item
+    short_words = sum(1 for word in path.words if len(word) <= 2)
+    return (score, short_words, len(path.words))
+
+
+def plausible_single_word_alignment(raw: str, word: str) -> bool:
+    if raw[0] == word[0] and raw[-1] == word[-1]:
+        return True
+    if len(raw) == len(word) + 1 and (raw[1:] == word or raw[:-1] == word):
+        return True
+    if len(word) == len(raw) + 1 and (word[1:] == raw or word[:-1] == raw):
+        return True
+    return False
+
+
+def load_language_model():
+    import kenlm
+
+    return kenlm.Model(str(DEFAULT_KENLM_MODEL_PATH))

--- a/apps/mobile/HandWave/Sources/Generated/OpenAPI/InferenceRecognitionState.swift
+++ b/apps/mobile/HandWave/Sources/Generated/OpenAPI/InferenceRecognitionState.swift
@@ -12,27 +12,36 @@ public struct InferenceRecognitionState: Sendable, Codable, Hashable {
 
     public var display: InferenceRecognitionScored?
     public var finalCandidate: InferenceRecognitionScored?
+    public var alternativeCandidate: InferenceRecognitionScored?
     public var selectedText: String
     public var selectedStreak: Int
     public var displayMisses: Int
     public var counts: [InferenceRecognitionCount]
+    public var alternativeCounts: [InferenceRecognitionCount]?
+    public var alternativeMisses: Int?
 
-    public init(display: InferenceRecognitionScored? = nil, finalCandidate: InferenceRecognitionScored? = nil, selectedText: String, selectedStreak: Int, displayMisses: Int, counts: [InferenceRecognitionCount]) {
+    public init(display: InferenceRecognitionScored? = nil, finalCandidate: InferenceRecognitionScored? = nil, alternativeCandidate: InferenceRecognitionScored? = nil, selectedText: String, selectedStreak: Int, displayMisses: Int, counts: [InferenceRecognitionCount], alternativeCounts: [InferenceRecognitionCount]? = nil, alternativeMisses: Int? = nil) {
         self.display = display
         self.finalCandidate = finalCandidate
+        self.alternativeCandidate = alternativeCandidate
         self.selectedText = selectedText
         self.selectedStreak = selectedStreak
         self.displayMisses = displayMisses
         self.counts = counts
+        self.alternativeCounts = alternativeCounts
+        self.alternativeMisses = alternativeMisses
     }
 
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case display
         case finalCandidate = "final_candidate"
+        case alternativeCandidate = "alternative_candidate"
         case selectedText = "selected_text"
         case selectedStreak = "selected_streak"
         case displayMisses = "display_misses"
         case counts
+        case alternativeCounts = "alternative_counts"
+        case alternativeMisses = "alternative_misses"
     }
 
     // Encodable protocol methods
@@ -41,10 +50,13 @@ public struct InferenceRecognitionState: Sendable, Codable, Hashable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(display, forKey: .display)
         try container.encodeIfPresent(finalCandidate, forKey: .finalCandidate)
+        try container.encodeIfPresent(alternativeCandidate, forKey: .alternativeCandidate)
         try container.encode(selectedText, forKey: .selectedText)
         try container.encode(selectedStreak, forKey: .selectedStreak)
         try container.encode(displayMisses, forKey: .displayMisses)
         try container.encode(counts, forKey: .counts)
+        try container.encodeIfPresent(alternativeCounts, forKey: .alternativeCounts)
+        try container.encodeIfPresent(alternativeMisses, forKey: .alternativeMisses)
     }
 }
 

--- a/apps/mobile/HandWave/Sources/Models/StreamModel.swift
+++ b/apps/mobile/HandWave/Sources/Models/StreamModel.swift
@@ -524,6 +524,13 @@ final class StreamModel {
     logSpeech(.pendingFired, prediction: prediction)
     resetPendingSpeech()
     speak(prediction)
+    if current?.text == prediction.text {
+      current = nil
+      logSpeech(.clear)
+    }
+    Task { [recognizer] in
+      await recognizer.resetAfterSpokenPartial()
+    }
   }
 
   private func cancelPendingSpeech(reason: String) {

--- a/apps/mobile/HandWave/Sources/Services/InferSession.swift
+++ b/apps/mobile/HandWave/Sources/Services/InferSession.swift
@@ -51,6 +51,7 @@ actor InferSession {
   private var requestId = 0
   private var pendingEvent: Event?
   private var pendingError: InferenceFailure?
+  private var hasDisplayedPrediction = false
   private var timing = StreamTiming(frameRate: Double(InferCfg.Stream.fps))
 
   init(client: InferAPI = InferClient()) {
@@ -72,8 +73,24 @@ actor InferSession {
     inFlight = false
     pendingEvent = nil
     pendingError = nil
+    hasDisplayedPrediction = false
     state = nil
     resetSegment()
+  }
+
+  func resetAfterSpokenPartial() {
+    epoch += 1
+    requestId += 1
+    inFlight = false
+    pendingError = nil
+    state = nil
+    resetSegment()
+    if hasDisplayedPrediction {
+      hasDisplayedPrediction = false
+      pendingEvent = .clear
+    } else {
+      pendingEvent = nil
+    }
   }
 
   func ingest(_ frame: LandmarkFrame?) async throws(InferenceFailure) -> Event? {
@@ -96,9 +113,17 @@ actor InferSession {
     last = frame
     lost = 0
     let moving = motion >= InferCfg.Stream.motion
+    var clearVisiblePrediction = false
 
     if moving {
-      if ended { resetSegment() }
+      if ended {
+        resetSegment()
+        last = frame
+        if hasDisplayedPrediction {
+          hasDisplayedPrediction = false
+          clearVisiblePrediction = true
+        }
+      }
       ended = false
       moved = true
       idle = 0
@@ -118,11 +143,11 @@ actor InferSession {
       return try await finalizeSegment(reason: .idle)
     }
 
-    if seen < timing.minFrames { return nil }
-    if seen % timing.stride != 0 || inFlight { return nil }
+    if seen < timing.minFrames { return clearVisiblePrediction ? .clear : nil }
+    if seen % timing.stride != 0 || inFlight { return clearVisiblePrediction ? .clear : nil }
 
     startDecode(batch: frames, idleFrames: idle, motion: motion)
-    return nil
+    return clearVisiblePrediction ? .clear : nil
   }
 
   private func startDecode(
@@ -168,10 +193,16 @@ actor InferSession {
     guard requestEpoch == epoch else { return }
 
     state = response.state
-    pendingEvent = response.displayPrediction.map {
-      Event.partial(
-        Self.prediction(from: $0, processingTimeMs: response.trace.decode?.latencyMs ?? 0)
+    if let prediction = response.displayPrediction {
+      hasDisplayedPrediction = true
+      pendingEvent = .partial(
+        Self.prediction(from: prediction, processingTimeMs: response.trace.decode?.latencyMs ?? 0)
       )
+    } else if hasDisplayedPrediction {
+      hasDisplayedPrediction = false
+      pendingEvent = .clear
+    } else {
+      pendingEvent = nil
     }
   }
 
@@ -211,6 +242,7 @@ actor InferSession {
   ) async throws(InferenceFailure) -> Event? {
     let currentState = state
     let context = endpointContext(reason)
+    let finalFrames = frames
     ended = true
     epoch += 1
     requestId += 1
@@ -220,23 +252,27 @@ actor InferSession {
     resetSegment()
 
     guard let currentState else {
+      hasDisplayedPrediction = false
       return .clear
     }
     let response = try await client.recognize(
-      frames: [],
+      frames: finalFrames,
       state: currentState,
       context: context,
       finalize: true
     )
 
     guard let prediction = response.displayPrediction, !prediction.label.isEmpty else {
+      hasDisplayedPrediction = false
       return .clear
     }
+    hasDisplayedPrediction = true
     return .finalized(Self.prediction(from: prediction, processingTimeMs: 0))
   }
 
   private func resetLive() {
     resetSegment()
+    hasDisplayedPrediction = false
     state = nil
   }
 

--- a/apps/mobile/HandWave/Sources/Services/Recognizer.swift
+++ b/apps/mobile/HandWave/Sources/Services/Recognizer.swift
@@ -36,6 +36,10 @@ actor Recognizer {
     await inference.setFrameRate(frameRate)
   }
 
+  func resetAfterSpokenPartial() async {
+    await inference.resetAfterSpokenPartial()
+  }
+
   func stop() async {
     detStarted = false
     inferStarted = false

--- a/apps/mobile/HandWave/Sources/Services/RecognizerClient.swift
+++ b/apps/mobile/HandWave/Sources/Services/RecognizerClient.swift
@@ -5,6 +5,7 @@ struct RecognizerClient: Sendable {
   var start: @Sendable () async throws -> Void
   var stop: @Sendable () async -> Void
   var setFrameRate: @Sendable (Double) async -> Void
+  var resetAfterSpokenPartial: @Sendable () async -> Void
   var process: @Sendable (VideoFrame) async throws -> Recognizer.Output
   var processCamera: @Sendable (CameraFrame) async throws -> Recognizer.Output
 }
@@ -22,6 +23,9 @@ extension RecognizerClient: DependencyKey {
       setFrameRate: { frameRate in
         await recognizer.setFrameRate(frameRate)
       },
+      resetAfterSpokenPartial: {
+        await recognizer.resetAfterSpokenPartial()
+      },
       process: { frame in
         try await recognizer.process(frame)
       },
@@ -35,6 +39,7 @@ extension RecognizerClient: DependencyKey {
     start: {},
     stop: {},
     setFrameRate: { _ in },
+    resetAfterSpokenPartial: {},
     process: { _ in
       Recognizer.Output(
         event: nil,
@@ -62,6 +67,9 @@ extension RecognizerClient: DependencyKey {
     },
     setFrameRate: { _ in
       reportIssue("RecognizerClient.setFrameRate is unimplemented")
+    },
+    resetAfterSpokenPartial: {
+      reportIssue("RecognizerClient.resetAfterSpokenPartial is unimplemented")
     },
     process: { _ in
       reportIssue("RecognizerClient.process is unimplemented")

--- a/apps/web/src/lib/inference/openapi.ts
+++ b/apps/web/src/lib/inference/openapi.ts
@@ -149,12 +149,15 @@ export interface components {
         RecognitionState: {
             display?: components["schemas"]["RecognitionScored"] | null;
             final_candidate?: components["schemas"]["RecognitionScored"] | null;
+            alternative_candidate?: components["schemas"]["RecognitionScored"] | null;
             selected_text: string;
             /** Format: int32 */
             selected_streak: number;
             /** Format: int32 */
             display_misses: number;
             counts: components["schemas"]["RecognitionCount"][];
+            alternative_counts?: components["schemas"]["RecognitionCount"][] | null;
+            alternative_misses?: number | null;
         };
         RecognitionTrace: {
             prediction?: components["schemas"]["PredictOut"] | null;

--- a/apps/web/src/lib/inference/stream.ts
+++ b/apps/web/src/lib/inference/stream.ts
@@ -140,6 +140,7 @@ export function createStreamCtrl(frameRate?: number): StreamCtrl {
   const finalize = (endpointReason: EndpointReason) => {
     const activeState = state;
     const context = endpointContext(endpointReason);
+    const finalFrames = frames.slice();
 
     clearHold();
     ended = true;
@@ -151,7 +152,7 @@ export function createStreamCtrl(frameRate?: number): StreamCtrl {
       return;
     }
     const finalEpoch = epoch;
-    void finalizeRemote(activeState, context, finalEpoch);
+    void finalizeRemote(activeState, context, finalFrames, finalEpoch);
   };
 
   const decode = async (batch: Frame[], idleFrames: number) => {
@@ -195,12 +196,14 @@ export function createStreamCtrl(frameRate?: number): StreamCtrl {
   const finalizeRemote = async (
     state: RecognitionState,
     context: RecognitionContext,
+    frames: Frame[],
     finalEpoch: number,
   ) => {
     let result: RecognizeOut;
     try {
       result = await run(
         recognizeFrames({
+          frames,
           state,
           context,
           finalize: true,

--- a/packages/contract/generated/json-schema/RecognitionState.json
+++ b/packages/contract/generated/json-schema/RecognitionState.json
@@ -23,6 +23,16 @@
                 }
             ]
         },
+        "alternative_candidate": {
+            "anyOf": [
+                {
+                    "$ref": "https://hand-wave.local/schemas/RecognitionScored.json"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "selected_text": {
             "type": "string"
         },
@@ -41,6 +51,31 @@
             "items": {
                 "$ref": "https://hand-wave.local/schemas/RecognitionCount.json"
             }
+        },
+        "alternative_counts": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://hand-wave.local/schemas/RecognitionCount.json"
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "alternative_misses": {
+            "anyOf": [
+                {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
     },
     "required": [

--- a/packages/contract/generated/openapi/openapi.json
+++ b/packages/contract/generated/openapi/openapi.json
@@ -466,6 +466,16 @@
               }
             ]
           },
+          "alternative_candidate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RecognitionScored"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "selected_text": {
             "type": "string"
           },
@@ -482,6 +492,30 @@
             "items": {
               "$ref": "#/components/schemas/RecognitionCount"
             }
+          },
+          "alternative_counts": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RecognitionCount"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alternative_misses": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "format": "int32"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },

--- a/packages/contract/main.tsp
+++ b/packages/contract/main.tsp
@@ -80,10 +80,13 @@ model RecognitionCount {
 model RecognitionState {
   display?: RecognitionScored | null;
   final_candidate?: RecognitionScored | null;
+  alternative_candidate?: RecognitionScored | null;
   selected_text: string;
   selected_streak: int32;
   display_misses: int32;
   counts: RecognitionCount[];
+  alternative_counts?: RecognitionCount[] | null;
+  alternative_misses?: int32 | null;
 }
 
 enum EndpointReason {


### PR DESCRIPTION
Adds recognition-state fields for alternative candidates and regenerates the inference, web, and mobile schemas.
Tunes CTC beam decoding, text normalization, and recognition smoothing so stale or low-confidence predictions are less likely to be spoken.
Updates mobile and web streaming to finalize with buffered frames and clear spoken partials more reliably.
Validated with `cd apps/inference && uv run ruff check src tests && uv run pytest`.